### PR TITLE
ci: fix failing build by installing wget

### DIFF
--- a/build/agent/Dockerfile
+++ b/build/agent/Dockerfile
@@ -9,6 +9,7 @@ RUN cd cmd/agent;go build -o /runner -mod mod -a .
 
 FROM bitnami/kubectl
 USER root
+RUN apt-get update && apt-get install -y wget
 RUN mkdir -p $HOME/.kubepug  && \
     cd $HOME/.kubepug && \
     wget https://github.com/rikatz/kubepug/releases/download/v1.1.3/kubepug_linux_amd64.tar.gz && \


### PR DESCRIPTION
## Pull request description 

Fix failing build: https://github.com/kubeshop/testkube-executor-kubepug/actions/runs/3136956972/jobs/5106612036

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

-